### PR TITLE
height_yarrrml_template.yaml replace baseURI with BASE

### DIFF
--- a/cde-ready-to-go/config/height_yarrrml_template.yaml
+++ b/cde-ready-to-go/config/height_yarrrml_template.yaml
@@ -8,7 +8,7 @@ prefixes:
   vocab: https://ejp-rd.eu/vocab/
   pico: http://data.cochrane.org/ontologies/pico/
   ndfrt: http://purl.bioontology.org/ontology/NDFRT/
-  this: |||baseURI|||
+  this: |||BASE|||
 sources:
   patient_height_experimental-source:
     access: "|||DATA|||"


### PR DESCRIPTION
according to 
https://github.com/ejp-rd-vp/CDE-semantic-model-implementations/blob/0160afe286f238d5f68085191a6691a7a9a374ad/YARRRML_Tools/yarrrml_template_builder/lib/yarrrml_template_builder/yarrrml_transform.rb#L111
the variable should be |||BASE|||